### PR TITLE
v1.2.0. Add HERO timer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](http://semver.org).
 
+## v1.2.0 - 2018-10-17
+### Changed
+- Added API to access HW cycles counters.
+
+
 ## v1.1.0 - 2018-09-25
 ### Fixed
 - Fix [#22](https://github.com/pulp-platform/hero-sdk/issues/22)

--- a/host/hero-target.c
+++ b/host/hero-target.c
@@ -96,3 +96,27 @@ hero_rt_core_id(void)
 {
   return omp_get_thread_num();
 }
+
+void
+hero_rt_start_cycle_cnt()
+{
+	return;
+}
+
+void
+hero_rt_reset_cycle_cnt()
+{
+	return;
+}
+
+void
+hero_rt_stop_cycle_cnt()
+{
+	return;
+}
+
+int
+hero_rt_get_cycles()
+{
+  return 0x0;
+}

--- a/inc/hero-target.h
+++ b/inc/hero-target.h
@@ -178,6 +178,44 @@ void hero_l2free(void * a);
   \return  The core ID.
  */
 int hero_rt_core_id();
+
+/** Start the processor cycle counter.
+
+    Start to commute the cycle counter. Note, at boot, the starting value is unpredictable because the counter is not automatically resetted during the `hero_rt_start_cycle_cnt` function. Reset must be manually controlled by the user. Following, the correct initialization sequence for the cycle counter:
+
+    ```
+    hero_rt_reset_cycle_cnt();
+    hero_rt_start_cycle_cnt();
+    ```
+
+  \return  void.
+ */
+void hero_rt_start_cycle_cnt();
+
+/** Reset the processor cycle counter.
+
+    Reset to 0 the processor cycle counter value.
+
+  \return  void.
+ */
+void hero_rt_reset_cycle_cnt();
+
+/** Stop the processor cycle counter.
+
+    Stop the processor cycle counter commutation. The cycle counter value can be readed using the function `hero_rt_get_cycles()`. The cycles counting can be resumed using the function `hero_rt_start_cycles_cnt()`.
+
+    Note. The counter value must be resetted manually by the user.
+
+  \return  void.
+ */
+void hero_rt_stop_cycle_cnt();
+
+/** Get the processor cycle counter value.
+
+  \return  the current cycle counter value, or 0 if unavailable.
+ */
+int hero_rt_get_cycles();
+
 //FIXME: hero_rt_info();
 //FIXME: hero_rt_error();
 

--- a/pulp/hero-target.c
+++ b/pulp/hero-target.c
@@ -152,3 +152,27 @@ hero_rt_core_id(void)
 {
   return rt_core_id();
 }
+
+void
+hero_rt_start_cycle_cnt()
+{
+  start_timer();
+}
+
+void
+hero_rt_reset_cycle_cnt()
+{
+  reset_timer();
+}
+
+void
+hero_rt_stop_cycle_cnt()
+{
+  stop_timer();
+}
+
+int
+hero_rt_get_cycles()
+{
+  return get_time();
+}


### PR DESCRIPTION
Add HERO API to access and control HW cycles counter on the accelerator side.

# Additional API
``` c
/** Start the processor cycle counter.

    Start to commute the cycle counter. Note, at boot, the starting value is unpredictable because the counter is not automatically resetted during the `hero_rt_start_cycle_cnt` function. Reset must be manually controlled by the user. Following, the correct initialization sequence for the cycle counter:

    ```
    hero_rt_reset_cycle_cnt();
    hero_rt_start_cycle_cnt();
    ```

  \return  void.
 */
void hero_rt_start_cycle_cnt();

/** Reset the processor cycle counter.

    Reset to 0 the processor cycle counter value.

  \return  void.
 */
void hero_rt_reset_cycle_cnt();

/** Stop the processor cycle counter.

    Stop the processor cycle counter commutation. The cycle counter value can be readed using the function `hero_rt_get_cycles()`. The cycles counting can be resumed using the function `hero_rt_start_cycles_cnt()`.

    Note. The counter value must be resetted manually by the user.

  \return  void.
 */
void hero_rt_stop_cycle_cnt();

/** Get the processor cycle counter value.

  \return  the current cycle counter value, or 0 if unavailable.
 */
int hero_rt_get_cycles();
```