### PR TITLE
Added the timer functions of the PULP runtime

### DIFF
--- a/host/hero-target.c
+++ b/host/hero-target.c
@@ -96,3 +96,13 @@ hero_rt_core_id(void)
 {
   return omp_get_thread_num();
 }
+
+void hero_reset_timer(void) {}
+
+void hero_start_timer(void) {}
+
+void hero_stop_timer(void) {}
+
+int hero_get_time(void) {
+    return 0;
+}

--- a/inc/hero-target.h
+++ b/inc/hero-target.h
@@ -181,6 +181,24 @@ int hero_rt_core_id();
 //FIXME: hero_rt_info();
 //FIXME: hero_rt_error();
 
+/** Calls the runtime function reset_timer() on PULP, does nothing on the HOST.
+*/
+void hero_reset_timer(void);
+
+/** Calls the runtime function start_timer() on PULP, does nothing on the HOST.
+*/
+void hero_start_timer(void);
+
+/** Calls the runtime function stop_timer() on PULP, does nothing on the HOST.
+*/
+void hero_stop_timer(void);
+
+/** Calls the runtime function get_time() on PULP, does nothing on the HOST.
+
+   \return  The cycles counted by the timer on PULP, 0 on the HOST.
+*/
+int hero_get_time(void);
+
 //!@}
 
 #endif

--- a/pulp/hero-target.c
+++ b/pulp/hero-target.c
@@ -152,3 +152,19 @@ hero_rt_core_id(void)
 {
   return rt_core_id();
 }
+
+void hero_reset_timer(void) {
+    reset_timer();
+}
+
+void hero_start_timer(void) {
+    start_timer();
+}
+
+void hero_stop_timer(void) {
+    stop_timer();
+}
+
+int hero_get_time(void) {
+    return get_time();
+}


### PR DESCRIPTION
Allows the timer to be used in OpenMP kernels.
Let me know if you want something changed (e.g., naming scheme or docs).